### PR TITLE
Add dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN zypper -n ref && \
       ruby \
       system-user-nobody \
       inotify-tools \
+      dumb-init \
       tini \
       ruby && \
     zypper clean


### PR DESCRIPTION
We don't need to download it every time we build the operator.