### PR TITLE
Add Dockerfile for s390x

### DIFF
--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,0 +1,8 @@
+FROM opensuse/leap:15.1
+RUN zypper --non-interactive install \
+      patch \
+      ruby \
+      system-user-nobody \
+      inotify-tools \
+      ruby && zypper clean
+RUN gem install bosh-template


### PR DESCRIPTION
An s390x version of the Dockerfile is needed to build the cf-operator-base on s390x.